### PR TITLE
Enable uWSGI for Load Balancing and Auto-Restart in Docker Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ENV FLASK_RUN_PORT=4321
 COPY ./ /source
 RUN apt-get update && apt-get install build-essential python3-dev -y
 RUN pip3 install -r /source/requirements.txt
-CMD ["flask", "run"]
+CMD ["uwsgi", "app.ini"]


### PR DESCRIPTION
# Description
This update ensures that the Docker container starts a uWSGI instance to enable load balancing with multiple Python instances. Additionally, it implements auto-restart in case a Python instance crashes, improving fault tolerance and system stability.
# Why
Better Performance: Distributes load across multiple Python instances.
Increased Stability: Prevents service disruptions by restarting failed instances.
Scalability: Allows efficient handling of multiple concurrent requests.